### PR TITLE
Adding Cordova fix for XHR caching issues

### DIFF
--- a/CordovaLib/cordova.ios.js
+++ b/CordovaLib/cordova.ios.js
@@ -1098,7 +1098,8 @@ function iOSExec() {
             execXhr = execXhr || new XMLHttpRequest();
             // Changing this to a GET will make the XHR reach the URIProtocol on 4.2.
             // For some reason it still doesn't work though...
-            execXhr.open('HEAD', "/!gap_exec", true);
+            // Add a timestamp to the query param to prevent caching.
+            execXhr.open('HEAD', "/!gap_exec?" + (+new Date()), true);
             if (!vcHeaderValue) {
                 vcHeaderValue = /.*\((.*)\)/.exec(navigator.userAgent)[1];
             }


### PR DESCRIPTION
This fixes an issue where XHR requests (to the Cordova bridge) were being cached, so data wasn't coming back between page loads.
