### PR TITLE
Updating the user agent configuration for InAppBrowser.

### DIFF
--- a/CordovaLib/Classes/CDVInAppBrowser.m
+++ b/CordovaLib/Classes/CDVInAppBrowser.m
@@ -91,7 +91,8 @@
 - (void)openInInAppBrowser:(NSURL*)url withOptions:(NSString*)options
 {
     if (self.inAppBrowserViewController == nil) {
-        NSString* originalUA = [CDVViewController originalUserAgent];
+        CDVViewController *vc = (CDVViewController *)self.viewController;
+        NSString *originalUA = [[vc class] originalUserAgent];
         self.inAppBrowserViewController = [[CDVInAppBrowserViewController alloc] initWithUserAgent:originalUA];
         self.inAppBrowserViewController.navigationDelegate = self;
 


### PR DESCRIPTION
InAppBrowser is hard-wiring its setting of its user agent to the default implementation in CDVViewController.  The Mobile SDK necessarily overrides this functionality, and InAppBrowser should allow for the use of an overridden function.
