### PR TITLE
Fixing splash screen in Cordova

### DIFF
--- a/CordovaLib/Classes/CDVViewController.h
+++ b/CordovaLib/Classes/CDVViewController.h
@@ -56,6 +56,7 @@
 @property (nonatomic, readonly, strong) CDVCommandQueue* commandQueue;
 @property (nonatomic, readonly, strong) CDVCommandDelegateImpl* commandDelegate;
 @property (nonatomic, readonly) NSString* userAgent;
+@property (nonatomic, readonly) BOOL splashScreenDisplayed;
 
 + (NSDictionary*)getBundlePlist:(NSString*)plistName;
 + (NSString*)applicationDocumentsDirectory;
@@ -64,6 +65,7 @@
 - (void)printMultitaskingInfo;
 - (void)createGapView;
 - (CDVCordovaView*)newCordovaViewWithFrame:(CGRect)bounds;
+- (void)showSplashScreen;
 
 - (void)javascriptAlert:(NSString*)text;
 - (NSString*)appURLScheme;


### PR DESCRIPTION
Cordova was creating the splash screen outside of the view hierarchy of the CDVViewController, which isn't really appropriate, and caused issues when we wanted to show other views modally on top of the CDVViewController.

I changed the implementation of the splash screen as follows:
- The splash screen is orchestrated as views in CDVViewController's view hierarchy (not the its super view's).
- I made `[CDVViewController showSplashScreen]` public, so that inheriting view controllers could call it explicitly.
- I made the splash screen view conform to the bounds of the view controller.  CDVViewController should not make assumptions about its bounds within the app (i.e. it doesn't have to be full screen).
- The CDVViewController parent class will still try to load the splash screen (if `useSplashScreen` is configured), but if it has already been displayed (by an inheriting class, for example), it will not attempt to load it.
