### PR TITLE
No implicit dependencies, parallel builds

### DIFF
--- a/CordovaLib/CordovaLib.xcodeproj/xcshareddata/xcschemes/CordovaLib.xcscheme
+++ b/CordovaLib/CordovaLib.xcodeproj/xcshareddata/xcschemes/CordovaLib.xcscheme
@@ -3,8 +3,8 @@
    LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"


### PR DESCRIPTION
Changing all projects in the SalesforceMobileSDK workspace to define dependent projects explicitly, and not to run parallel builds, which cause problems with our builds scripts.
