### PR TITLE
Fixing iOS 7.1 errors (64-bit)

### DIFF
--- a/CordovaLib/Classes/JSON/JSONKit.m
+++ b/CordovaLib/Classes/JSON/JSONKit.m
@@ -677,7 +677,7 @@ static CDVJKArray *_CDVJKArrayCreate(id *objects, NSUInteger count, BOOL mutable
   NSCParameterAssert((objects != NULL) && (_CDVJKArrayClass != NULL) && (_CDVJKArrayInstanceSize > 0UL));
   CDVJKArray *array = NULL;
   if(CDVJK_EXPECT_T((array = (CDVJKArray *)calloc(1UL, _CDVJKArrayInstanceSize)) != NULL)) { // Directly allocate the CDVJKArray instance via calloc.
-    array->isa      = _CDVJKArrayClass;
+    object_setClass(array, _CDVJKArrayClass);
     if((array = [array init]) == NULL) { return(NULL); }
     array->capacity = count;
     array->count    = count;
@@ -928,7 +928,7 @@ static CDVJKDictionary *_CDVJKDictionaryCreate(id *keys, NSUInteger *keyHashes, 
   NSCParameterAssert((keys != NULL) && (keyHashes != NULL) && (objects != NULL) && (_CDVJKDictionaryClass != NULL) && (_CDVJKDictionaryInstanceSize > 0UL));
   CDVJKDictionary *dictionary = NULL;
   if(CDVJK_EXPECT_T((dictionary = (CDVJKDictionary *)calloc(1UL, _CDVJKDictionaryInstanceSize)) != NULL)) { // Directly allocate the CDVJKDictionary instance via calloc.
-    dictionary->isa      = _CDVJKDictionaryClass;
+    object_setClass(dictionary, _CDVJKDictionaryClass);
     if((dictionary = [dictionary init]) == NULL) { return(NULL); }
     dictionary->capacity = _CDVJKDictionaryCapacityForCount(count);
     dictionary->count    = 0UL;


### PR DESCRIPTION
**Note:** This seems to clear the way for being able to build to 64-bit devices, but Cordova apps still don't work on 64-bit devices (e.g. the 5S).  I get a runtime error when trying to run our sample apps.  This just fixes the compile time errors.
